### PR TITLE
T1: turn enforcement

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -31,7 +31,7 @@ bottom as a future "Could" tier, not committed to).
 ### T1 — Turn enforcement
 Right now either color can move any piece at any time. Need to track whose turn
 it is and reject moves by the wrong color.
-**Status:** Ready
+**Status:** Done
 
 **Acceptance criteria:**
 - A new game starts with white to move.

--- a/src/components/board/Board.js
+++ b/src/components/board/Board.js
@@ -42,11 +42,12 @@ const updatePieceInArray = (previousSelectedPiece, clickedSquare, pieces) => {
 const shouldDeselectPreviousSquare = (selectedSquare, id) =>
   selectedSquare && selectedSquare !== id;
 
-const shouldHighlightSquare = (copyPieces, clickedSquare) => {
+const shouldHighlightSquare = (copyPieces, clickedSquare, isWhiteTurn) => {
   return copyPieces.find(
     (piece) =>
       Object.is(piece.positionY, clickedSquare.positionY) &&
-      Object.is(piece.positionX, clickedSquare.positionX)
+      Object.is(piece.positionX, clickedSquare.positionX) &&
+      Object.is(piece.isWhite, isWhiteTurn)
   );
 };
 
@@ -78,7 +79,7 @@ const shouldMovePiece = ({
   );
 };
 
-function Board({ pieces, setPieces }) {
+function Board({ pieces, setPieces, isWhiteTurn, setIsWhiteTurn }) {
   const [squares, setSquares] = useState([]);
   const [selectedSquare, setSelectedSquare] = useState();
   const [initialized, setInitialized] = useState(false);
@@ -100,7 +101,7 @@ function Board({ pieces, setPieces }) {
         setSelectedSquare(null);
       }
 
-      if (shouldHighlightSquare(copyPieces, clickedSquare)) {
+      if (shouldHighlightSquare(copyPieces, clickedSquare, isWhiteTurn)) {
         const newSelectedSquare = { ...clickedSquare, isSelected: true };
         const copyWithSelectedSquares = selectSquareInArray(
           squares,
@@ -141,10 +142,11 @@ function Board({ pieces, setPieces }) {
           );
 
           setPieces([copyPiecesArrayWithNewPosition]); // Why array in array?
+          setIsWhiteTurn(!isWhiteTurn);
         }
       }
     },
-    [squares, selectedSquare, report, pieces, setPieces]
+    [squares, selectedSquare, report, pieces, setPieces, isWhiteTurn, setIsWhiteTurn]
   );
 
   useEffect(() => {

--- a/src/components/board/__tests__/Board.test.js
+++ b/src/components/board/__tests__/Board.test.js
@@ -1,11 +1,110 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import Board from '../Board';
+import React, { useState } from "react";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import Board from "../Board";
+import { getStartPosition } from "../../game/GameUtils";
 
-describe("Board", () => {
-    test.skip("should render without crashing", () => {
-        const div = document.createElement('div');
-        ReactDOM.render(<Board />, div);
-        ReactDOM.unmountComponentAtNode(div);
-    });
+afterEach(cleanup);
+
+// Mirrors how Board.js lays squares out: row 8 (a..h) first, down to row 1,
+// so a square's index can be derived from its board position.
+const squareIndexFor = (positionY, positionX) =>
+  (8 - positionY) * 8 + (positionX - 1);
+
+function TestGame() {
+  const [pieces, setPieces] = useState([getStartPosition]);
+  const [isWhiteTurn, setIsWhiteTurn] = useState(true);
+
+  return (
+    <>
+      <div data-testid="turn">{isWhiteTurn ? "white" : "black"}</div>
+      <Board
+        pieces={pieces}
+        setPieces={setPieces}
+        isWhiteTurn={isWhiteTurn}
+        setIsWhiteTurn={setIsWhiteTurn}
+      />
+    </>
+  );
+}
+
+const clickSquare = (container, positionY, positionX) => {
+  const squares = container.querySelectorAll('[data-cy="square"]');
+  fireEvent.click(squares[squareIndexFor(positionY, positionX)]);
+};
+
+const hasSelectedSquare = (container) =>
+  container.querySelector(".board__square--selected") !== null;
+
+describe("Board turn enforcement", () => {
+  test("white moves first", () => {
+    //Arrange
+    const { getByTestId } = render(<TestGame />);
+
+    //Assert
+    expect(getByTestId("turn").textContent).toBe("white");
+  });
+
+  test("clicking a black piece on white's turn is a silent no-op", () => {
+    //Arrange
+    const { container, getByTestId } = render(<TestGame />);
+
+    //Act - pawn7a is black
+    clickSquare(container, 7, 1);
+
+    //Assert
+    expect(hasSelectedSquare(container)).toBe(false);
+    expect(getByTestId("turn").textContent).toBe("white");
+  });
+
+  test("a legal move by white hands the turn to black", () => {
+    //Arrange
+    const { container, getByTestId } = render(<TestGame />);
+
+    //Act - select white pawn2a, move it to y4 (two-square opening move)
+    clickSquare(container, 2, 1);
+    clickSquare(container, 4, 1);
+
+    //Assert
+    expect(getByTestId("turn").textContent).toBe("black");
+  });
+
+  test("an illegal move attempt does not change whose turn it is", () => {
+    //Arrange
+    const { container, getByTestId } = render(<TestGame />);
+
+    //Act - select white pawn2a, attempt an illegal sideways move
+    clickSquare(container, 2, 1);
+    clickSquare(container, 2, 2);
+
+    //Assert
+    expect(getByTestId("turn").textContent).toBe("white");
+  });
+
+  test("white cannot select a piece again once it is black's turn", () => {
+    //Arrange
+    const { container, getByTestId } = render(<TestGame />);
+
+    //Act - white plays a legal move, then tries to select another white piece
+    clickSquare(container, 2, 1);
+    clickSquare(container, 4, 1);
+    clickSquare(container, 2, 2); // white pawn2b
+
+    //Assert
+    expect(getByTestId("turn").textContent).toBe("black");
+    expect(hasSelectedSquare(container)).toBe(false);
+  });
+
+  test("after white moves, black can select and move their own piece", () => {
+    //Arrange
+    const { container, getByTestId } = render(<TestGame />);
+
+    //Act - white opens, then black opens
+    clickSquare(container, 2, 1);
+    clickSquare(container, 4, 1);
+    clickSquare(container, 7, 2);
+    clickSquare(container, 5, 2);
+
+    //Assert
+    expect(getByTestId("turn").textContent).toBe("white");
+  });
 });

--- a/src/components/game/Game.js
+++ b/src/components/game/Game.js
@@ -8,6 +8,7 @@ import { getStartPosition } from "./GameUtils";
 function Game() {
   const [pieces, setPieces] = useState([]); //why array with an array?
   const [initialized, setInitialized] = useState(false);
+  const [isWhiteTurn, setIsWhiteTurn] = useState(true);
 
   useEffect(() => {
     if (!initialized) {
@@ -19,7 +20,12 @@ function Game() {
   return (
     <div className="game-wrapper">
       <VerticalDescription />
-      <Board pieces={pieces} setPieces={setPieces} />
+      <Board
+        pieces={pieces}
+        setPieces={setPieces}
+        isWhiteTurn={isWhiteTurn}
+        setIsWhiteTurn={setIsWhiteTurn}
+      />
       <HorizontalDescription />
     </div>
   );


### PR DESCRIPTION
## Summary
Implements T1 from BACKLOG.md against the acceptance criteria in #6.

- `Game.js` now owns `isWhiteTurn` state, initialized to white.
- `Board.js`'s `shouldHighlightSquare` only lets you select a piece that belongs to the player whose turn it is; clicking an opponent's piece with nothing already selected is a silent no-op (no selection, no error, no state change).
- Clicking a square with the opponent's piece now falls through to the move-attempt path (same as an empty square) instead of re-selecting it — this was flagged and agreed as necessary scaffolding for T2 (capture logic), not an implementation of capturing itself; captured pieces still aren't removed yet.
- Turn only flips after `shouldMovePiece` accepts a move; a rejected move attempt leaves the turn unchanged.
- No UI indicator added (explicitly out of scope per the spec).

## How this was verified
- `npm test`: all suites pass, including 6 new interaction tests in `Board.test.js` (React Testing Library) covering: white moves first, wrong-turn clicks no-op, legal moves flip the turn, illegal moves don't, and both colors can select/move only on their own turn.
- Manually verified in a real browser against a production build (the dev server's hot-reload tooling hits an unrelated environment issue in this sandbox — production build compiles and runs fine) — walked through the full click sequence and confirmed selection/turn behavior matches the AC.

## Test plan
- [x] `npm test` passes
- [x] Manual click-through in browser confirms AC


---
_Generated by [Claude Code](https://claude.ai/code/session_01NULuXwvh8pynRN9gpQqEgu)_