### PR TITLE
Rename updatePieceInArray to applyMoveToPieces

### DIFF
--- a/src/components/board/Board.js
+++ b/src/components/board/Board.js
@@ -25,7 +25,7 @@ const selectSquareInArray = (squares, clickedSquare) => {
   });
 };
 
-const updatePieceInArray = (previousSelectedPiece, clickedSquare, pieces) => {
+const applyMoveToPieces = (previousSelectedPiece, clickedSquare, pieces) => {
   return pieces
     .filter(
       (piece) =>
@@ -142,7 +142,7 @@ function Board({ pieces, setPieces, isWhiteTurn, setIsWhiteTurn }) {
             pieces,
           })
         ) {
-          const copyPiecesArrayWithNewPosition = updatePieceInArray(
+          const copyPiecesArrayWithNewPosition = applyMoveToPieces(
             previousSelectedPiece,
             clickedSquare,
             copyPieces


### PR DESCRIPTION
## Summary
- Pure rename, no behavior change: `updatePieceInArray` → `applyMoveToPieces` in `Board.js`.
- Flagged during T2 review — the name only described the "update position" half of what the function does; since T2 it also removes any captured piece from the array, so the old name undersold it.

## Test plan
- [x] `npm test` passes (no behavior change, same 31 passing tests)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NULuXwvh8pynRN9gpQqEgu)_