### PR TITLE
T4: piece/state model cleanup

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -107,7 +107,7 @@ correctly; flagged and agreed before fixing rather than assumed.
 `pieces[pieces.length - 1]` everywhere. Flagged in the code itself as unclear
 ("why array with an array?"). Needs a clean single-array model before check
 detection and later move-history-dependent rules build on top of it.
-**Status:** Ready
+**Status:** Done
 **Depends on:** none, but blocks T5–T8 (cleaner to build check/checkmate logic
 on the new model).
 

--- a/src/components/board/Board.js
+++ b/src/components/board/Board.js
@@ -96,7 +96,7 @@ function Board({ pieces, setPieces, isWhiteTurn, setIsWhiteTurn }) {
   const squareClicked = useCallback(
     (id) => {
       // Is this needed? To Copy the array.
-      const copyPieces = Array.from(pieces[pieces.length - 1]);
+      const copyPieces = Array.from(pieces);
       const clickedSquare = squares.find((square) => square.id === id);
 
       if (shouldDeselectPreviousSquare(selectedSquare, id)) {
@@ -148,7 +148,7 @@ function Board({ pieces, setPieces, isWhiteTurn, setIsWhiteTurn }) {
             copyPieces
           );
 
-          setPieces([copyPiecesArrayWithNewPosition]); // Why array in array?
+          setPieces(copyPiecesArrayWithNewPosition);
           setIsWhiteTurn(!isWhiteTurn);
         }
       }
@@ -192,9 +192,7 @@ function Board({ pieces, setPieces, isWhiteTurn, setIsWhiteTurn }) {
 
     setSquaresAndPieces(
       squares.map((square, index) => {
-        //test what is the fastes way to get copy from last element in array
-        const lastPieces = Array.from(pieces[pieces.length - 1]);
-        const piece = lastPieces.find(
+        const piece = pieces.find(
           (piece) =>
             Object.is(piece.positionY, square.positionY) &&
             Object.is(piece.positionX, square.positionX)

--- a/src/components/board/__tests__/Board.test.js
+++ b/src/components/board/__tests__/Board.test.js
@@ -11,7 +11,7 @@ const squareIndexFor = (positionY, positionX) =>
   (8 - positionY) * 8 + (positionX - 1);
 
 function TestGame({ initialPieces = getStartPosition, initialIsWhiteTurn = true }) {
-  const [pieces, setPieces] = useState([initialPieces]);
+  const [pieces, setPieces] = useState(initialPieces);
   const [isWhiteTurn, setIsWhiteTurn] = useState(initialIsWhiteTurn);
 
   return (

--- a/src/components/game/Game.js
+++ b/src/components/game/Game.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import "./Game.css";
 import Board from "../board/Board";
 import VerticalDescription from "../verticalDescription/VerticalDescription";
@@ -6,16 +6,8 @@ import HorizontalDescription from "../horizontalDescription/HorizontalDescriptio
 import { getStartPosition } from "./GameUtils";
 
 function Game() {
-  const [pieces, setPieces] = useState([]); //why array with an array?
-  const [initialized, setInitialized] = useState(false);
+  const [pieces, setPieces] = useState(getStartPosition);
   const [isWhiteTurn, setIsWhiteTurn] = useState(true);
-
-  useEffect(() => {
-    if (!initialized) {
-      setPieces([getStartPosition]);
-      setInitialized(true);
-    }
-  }, [initialized]);
 
   return (
     <div className="game-wrapper">

--- a/src/components/piece/PiecesRules.js
+++ b/src/components/piece/PiecesRules.js
@@ -101,7 +101,7 @@ const getSquersInPath = (currentPosition, nextPosition) => {
 };
 
 const isOwnPieceAt = (position, isWhite, pieces) =>
-  Array.from(pieces[pieces.length - 1]).some(
+  pieces.some(
     (piece) =>
       piece.positionY === position.y &&
       piece.positionX === position.x &&
@@ -109,7 +109,7 @@ const isOwnPieceAt = (position, isWhite, pieces) =>
   );
 
 const isOpponentPieceAt = (position, isWhite, pieces) =>
-  Array.from(pieces[pieces.length - 1]).some(
+  pieces.some(
     (piece) =>
       piece.positionY === position.y &&
       piece.positionX === position.x &&
@@ -120,7 +120,7 @@ const checkSquares = (squaresInPath, pieces) => {
   let isValidPath = true;
 
   squaresInPath.some((square) => {
-    const hasPieceInSquare = Array.from(pieces[pieces.length - 1]).some(
+    const hasPieceInSquare = pieces.some(
       (piece) => piece.positionY === square.y && piece.positionX === square.x
     );
 

--- a/src/components/piece/__tests__/Piece.test.js
+++ b/src/components/piece/__tests__/Piece.test.js
@@ -19,7 +19,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 1, x: 1 }
             const nextPostition = { y: 3, x: 1 }
     
-            const pieces = [getStartPosition]; // create test senario 
+            const pieces = getStartPosition; // create test senario 
             let validMove = true;
     
             //Act 
@@ -34,7 +34,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 3, x: 1 }
             const nextPostition = { y: 6, x: 1 }
     
-            const pieces = [getStartPosition]; // create test senario 
+            const pieces = getStartPosition; // create test senario 
             let validMove = true;
     
             //Act 
@@ -51,7 +51,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 1, x: 1 }
             const nextPostition = { y: 1, x: 3 }
     
-            const pieces = [getStartPosition]; // create test senario 
+            const pieces = getStartPosition; // create test senario 
             let validMove = true;
     
             //Act 
@@ -66,7 +66,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 1, x: 3 }
             const nextPostition = { y: 1, x: 1 }
     
-            const pieces = [getStartPosition]; // create test senario 
+            const pieces = getStartPosition; // create test senario 
             let validMove = true;
     
             //Act 
@@ -81,7 +81,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 3, x: 1 }
             const nextPostition = { y: 3, x: 3 }
     
-            const pieces = [getStartPosition]; // create test senario 
+            const pieces = getStartPosition; // create test senario 
             let validMove = true;
     
             //Act 
@@ -96,7 +96,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 3, x: 3 }
             const nextPostition = { y: 3, x: 1 }
     
-            const pieces = [getStartPosition]; // create test senario 
+            const pieces = getStartPosition; // create test senario 
             let validMove = true;
     
             //Act 
@@ -112,7 +112,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 1, x: 3 }
             const nextPostition = { y: 3, x: 5 }
     
-            const pieces = [getStartPosition];  
+            const pieces = getStartPosition;  
             let validMove = true;
     
             //Act 
@@ -127,7 +127,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 1, x: 3 }
             const nextPostition = { y: 3, x: 1 }
     
-            const pieces = [getStartPosition];  
+            const pieces = getStartPosition;  
             let validMove = true;
     
             //Act 
@@ -142,7 +142,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 5, x: 3 }
             const nextPostition = { y: 3, x: 5 }
     
-            const pieces = [getStartPosition];  
+            const pieces = getStartPosition;  
             let validMove = true;
     
             //Act 
@@ -157,7 +157,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 5, x: 3 }
             const nextPostition = { y: 3, x: 1 }
     
-            const pieces = [getStartPosition];  
+            const pieces = getStartPosition;  
             let validMove = true;
     
             //Act 
@@ -172,7 +172,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 3, x: 3 }
             const nextPostition = { y: 5, x: 1 }
     
-            const pieces = [getStartPosition];  
+            const pieces = getStartPosition;  
             let validMove = true;
     
             //Act 
@@ -187,7 +187,7 @@ describe("Path validation", () => {
             const currentPosition = { y: 3, x: 3 }
             const nextPostition = { y: 5, x: 5 }
     
-            const pieces = [getStartPosition];  
+            const pieces = getStartPosition;  
             let validMove = true;
     
             //Act 
@@ -203,7 +203,7 @@ describe("Path validation", () => {
             //Arrange
             const currentPosition = { y: 1, x: 4 }
             const nextPostition = { y: 1, x: 8 }
-            const pieces = [[{ id: "blockerA", isWhite: true, type: 1, positionY: 1, positionX: 6 }]];
+            const pieces = [{ id: "blockerA", isWhite: true, type: 1, positionY: 1, positionX: 6 }];
 
             //Act
             const validMove = checkPath(currentPosition, nextPostition, pieces);
@@ -216,7 +216,7 @@ describe("Path validation", () => {
             //Arrange
             const currentPosition = { y: 1, x: 4 }
             const nextPostition = { y: 1, x: 8 }
-            const pieces = [[]];
+            const pieces = [];
 
             //Act
             const validMove = checkPath(currentPosition, nextPostition, pieces);
@@ -229,7 +229,7 @@ describe("Path validation", () => {
             //Arrange
             const currentPosition = { y: 1, x: 1 }
             const nextPostition = { y: 5, x: 5 }
-            const pieces = [[{ id: "blockerA", isWhite: true, type: 1, positionY: 3, positionX: 3 }]];
+            const pieces = [{ id: "blockerA", isWhite: true, type: 1, positionY: 3, positionX: 3 }];
 
             //Act
             const validMove = checkPath(currentPosition, nextPostition, pieces);
@@ -245,9 +245,9 @@ describe("Queen movement rules", () => {
 
     test("Should be able to move in a straight line with a clear path", () => {
         //Arrange
-        const pieces = [[
+        const pieces = [
             { id: "queenA", isWhite: true, type: pieceTypes.Queen, positionY: 1, positionX: 4 },
-        ]];
+        ];
         const currentPosition = { y: 1, x: 4 };
         const nextPosition = { y: 1, x: 8 };
 
@@ -260,9 +260,9 @@ describe("Queen movement rules", () => {
 
     test("Should be able to move diagonally with a clear path", () => {
         //Arrange
-        const pieces = [[
+        const pieces = [
             { id: "queenA", isWhite: true, type: pieceTypes.Queen, positionY: 1, positionX: 4 },
-        ]];
+        ];
         const currentPosition = { y: 1, x: 4 };
         const nextPosition = { y: 4, x: 7 };
 
@@ -275,9 +275,9 @@ describe("Queen movement rules", () => {
 
     test("Should not be able to move like a knight", () => {
         //Arrange
-        const pieces = [[
+        const pieces = [
             { id: "queenA", isWhite: true, type: pieceTypes.Queen, positionY: 1, positionX: 4 },
-        ]];
+        ];
         const currentPosition = { y: 1, x: 4 };
         const nextPosition = { y: 3, x: 5 };
 
@@ -290,10 +290,10 @@ describe("Queen movement rules", () => {
 
     test("Should not be able to move through a piece blocking a straight path", () => {
         //Arrange
-        const pieces = [[
+        const pieces = [
             { id: "queenA", isWhite: true, type: pieceTypes.Queen, positionY: 1, positionX: 4 },
             { id: "blockerA", isWhite: true, type: pieceTypes.Pawn, positionY: 1, positionX: 6 },
-        ]];
+        ];
         const currentPosition = { y: 1, x: 4 };
         const nextPosition = { y: 1, x: 8 };
 
@@ -306,10 +306,10 @@ describe("Queen movement rules", () => {
 
     test("Should not be able to move through a piece blocking a diagonal path", () => {
         //Arrange
-        const pieces = [[
+        const pieces = [
             { id: "queenA", isWhite: true, type: pieceTypes.Queen, positionY: 1, positionX: 4 },
             { id: "blockerA", isWhite: true, type: pieceTypes.Pawn, positionY: 2, positionX: 5 },
-        ]];
+        ];
         const currentPosition = { y: 1, x: 4 };
         const nextPosition = { y: 4, x: 7 };
 

--- a/src/components/piece/__tests__/PiecesRules.test.js
+++ b/src/components/piece/__tests__/PiecesRules.test.js
@@ -87,10 +87,10 @@ describe("Pawn capture rules", () => {
 describe("rules() same-color and capture handling", () => {
     test("rejects a move onto a square occupied by your own piece", () => {
         //Arrange
-        const pieces = [[
+        const pieces = [
             { id: "rookA", isWhite: true, type: pieceTypes.Rook, positionY: 1, positionX: 1 },
             { id: "pawnA", isWhite: true, type: pieceTypes.Pawn, positionY: 1, positionX: 4 },
-        ]];
+        ];
         const currentPosition = { y: 1, x: 1 };
         const nextPosition = { y: 1, x: 4 };
         const report = jest.fn();
@@ -105,10 +105,10 @@ describe("rules() same-color and capture handling", () => {
 
     test("allows a rook to capture an opponent piece with a clear path", () => {
         //Arrange
-        const pieces = [[
+        const pieces = [
             { id: "rookA", isWhite: true, type: pieceTypes.Rook, positionY: 1, positionX: 1 },
             { id: "pawnB", isWhite: false, type: pieceTypes.Pawn, positionY: 1, positionX: 4 },
-        ]];
+        ];
         const currentPosition = { y: 1, x: 1 };
         const nextPosition = { y: 1, x: 4 };
         const report = jest.fn();
@@ -122,10 +122,10 @@ describe("rules() same-color and capture handling", () => {
 
     test("allows a knight to capture an opponent piece", () => {
         //Arrange
-        const pieces = [[
+        const pieces = [
             { id: "knightA", isWhite: true, type: pieceTypes.Knight, positionY: 1, positionX: 1 },
             { id: "pawnB", isWhite: false, type: pieceTypes.Pawn, positionY: 3, positionX: 2 },
-        ]];
+        ];
         const currentPosition = { y: 1, x: 1 };
         const nextPosition = { y: 3, x: 2 };
         const report = jest.fn();


### PR DESCRIPTION
## Summary
Implements T4 against the acceptance criteria in #14.

- `pieces` is now a flat array of piece objects everywhere — no more `[actualArray]` wrapping, no more `pieces[pieces.length - 1]` (or `Array.from(pieces[pieces.length - 1])`) anywhere in `Game.js`, `Board.js`, or `PiecesRules.js`.
- `Game.js` initializes state directly with `useState(getStartPosition)`; the `useEffect` + `initialized` boolean that only existed to defer setting the old wrapped value is gone. (`Board.js`'s separate `initialized` flag for building the 64 squares is unrelated and untouched.)
- Removed the now-stale comments that were literally describing the bug this ticket fixes (`why array with an array?`, `Why array in array?`, `last element in array`).
- No change to the piece object shape, the linear `.find()`/`.some()` lookup pattern, or any history/undo behavior — scoped exactly to removing the wrapping, per the spec.

## How this was verified
- `npm test`: all suites pass — 39 tests (up from 31; the increase is just test-file reshuffling across earlier tickets, no new tests added here since this is a pure refactor with no new behavior).
- Updated every existing test fixture that constructed `pieces` in the old array-of-array shape (`Board.test.js`, `Piece.test.js`, `PiecesRules.test.js`) — same assertions, only fixture shape changed.
- Built a production bundle and re-ran the same click-through sequence used to verify T1 (select → move → wrong-turn no-op → opponent moves → turn returns) against the compiled app — identical behavior before and after, confirming this is a true no-behavior-change refactor.

## Test plan
- [x] `npm test` passes
- [x] AC in #14 reviewed against the diff
- [x] Manual click-through against a production build shows no behavior change


---
_Generated by [Claude Code](https://claude.ai/code/session_01NULuXwvh8pynRN9gpQqEgu)_