### PR TITLE
T5: check detection

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -136,7 +136,7 @@ on the new model).
 
 ### T5 — Check detection
 Determine whether a given king is currently in check, given a board position.
-**Status:** Ready
+**Status:** Done
 **Depends on:** T4
 
 **Acceptance criteria:**

--- a/src/components/piece/PiecesRules.js
+++ b/src/components/piece/PiecesRules.js
@@ -200,3 +200,30 @@ export const rules = (
 
   return validMove;
 };
+
+const noopReport = () => {};
+
+export const isKingInCheck = (isWhite, pieces) => {
+  const king = pieces.find(
+    (piece) => piece.type === pieceTypes.King && piece.isWhite === isWhite
+  );
+
+  if (!king) {
+    return false;
+  }
+
+  const kingPosition = { y: king.positionY, x: king.positionX };
+
+  return pieces.some(
+    (piece) =>
+      piece.isWhite !== isWhite &&
+      rules(
+        piece.type,
+        piece.isWhite,
+        { y: piece.positionY, x: piece.positionX },
+        kingPosition,
+        pieces,
+        noopReport
+      )
+  );
+};

--- a/src/components/piece/__tests__/PiecesRules.test.js
+++ b/src/components/piece/__tests__/PiecesRules.test.js
@@ -1,4 +1,4 @@
-import { pawnRules, rules, pieceTypes } from '../PiecesRules';
+import { pawnRules, rules, pieceTypes, isKingInCheck } from '../PiecesRules';
 
 describe("Pawn capture rules", () => {
     describe("White", () => {
@@ -135,5 +135,119 @@ describe("rules() same-color and capture handling", () => {
 
         //Assert
         expect(validMove).toBe(true);
+    });
+});
+
+describe("isKingInCheck", () => {
+    test("is true when an opponent rook has a clear line to the king", () => {
+        //Arrange
+        const pieces = [
+            { id: "kingA", isWhite: true, type: pieceTypes.King, positionY: 1, positionX: 5 },
+            { id: "rookB", isWhite: false, type: pieceTypes.Rook, positionY: 1, positionX: 1 },
+        ];
+
+        //Act
+        const inCheck = isKingInCheck(true, pieces);
+
+        //Assert
+        expect(inCheck).toBe(true);
+    });
+
+    test("is false when the attacking piece's path to the king is blocked", () => {
+        //Arrange
+        const pieces = [
+            { id: "kingA", isWhite: true, type: pieceTypes.King, positionY: 1, positionX: 5 },
+            { id: "rookB", isWhite: false, type: pieceTypes.Rook, positionY: 1, positionX: 1 },
+            { id: "blockerA", isWhite: true, type: pieceTypes.Pawn, positionY: 1, positionX: 3 },
+        ];
+
+        //Act
+        const inCheck = isKingInCheck(true, pieces);
+
+        //Assert
+        expect(inCheck).toBe(false);
+    });
+
+    test("is true when an opponent knight threatens the king", () => {
+        //Arrange
+        const pieces = [
+            { id: "kingA", isWhite: true, type: pieceTypes.King, positionY: 1, positionX: 5 },
+            { id: "knightB", isWhite: false, type: pieceTypes.Knight, positionY: 2, positionX: 3 },
+        ];
+
+        //Act
+        const inCheck = isKingInCheck(true, pieces);
+
+        //Assert
+        expect(inCheck).toBe(true);
+    });
+
+    test("is true when an opponent pawn threatens the king diagonally", () => {
+        //Arrange
+        const pieces = [
+            { id: "kingA", isWhite: true, type: pieceTypes.King, positionY: 5, positionX: 5 },
+            { id: "pawnB", isWhite: false, type: pieceTypes.Pawn, positionY: 6, positionX: 4 },
+        ];
+
+        //Act
+        const inCheck = isKingInCheck(true, pieces);
+
+        //Assert
+        expect(inCheck).toBe(true);
+    });
+
+    test("is true when an opponent queen threatens the king diagonally", () => {
+        //Arrange
+        const pieces = [
+            { id: "kingA", isWhite: true, type: pieceTypes.King, positionY: 1, positionX: 5 },
+            { id: "queenB", isWhite: false, type: pieceTypes.Queen, positionY: 5, positionX: 1 },
+        ];
+
+        //Act
+        const inCheck = isKingInCheck(true, pieces);
+
+        //Assert
+        expect(inCheck).toBe(true);
+    });
+
+    test("is false when no opponent piece can reach the king", () => {
+        //Arrange
+        const pieces = [
+            { id: "kingA", isWhite: true, type: pieceTypes.King, positionY: 1, positionX: 5 },
+            { id: "rookB", isWhite: false, type: pieceTypes.Rook, positionY: 8, positionX: 1 },
+        ];
+
+        //Act
+        const inCheck = isKingInCheck(true, pieces);
+
+        //Assert
+        expect(inCheck).toBe(false);
+    });
+
+    test("is false when the only piece that could reach the square is the same color as the king", () => {
+        //Arrange
+        const pieces = [
+            { id: "kingA", isWhite: true, type: pieceTypes.King, positionY: 1, positionX: 5 },
+            { id: "rookA", isWhite: true, type: pieceTypes.Rook, positionY: 1, positionX: 1 },
+        ];
+
+        //Act
+        const inCheck = isKingInCheck(true, pieces);
+
+        //Assert
+        expect(inCheck).toBe(false);
+    });
+
+    test("is false when the given color's king isn't on the board", () => {
+        //Arrange
+        const pieces = [
+            { id: "rookB", isWhite: false, type: pieceTypes.Rook, positionY: 1, positionX: 1 },
+        ];
+
+        //Act
+        const inCheck = isKingInCheck(true, pieces);
+
+        //Assert
+        expect(inCheck).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
Implements T5 against the acceptance criteria in #16.

- New exported `isKingInCheck(isWhite, pieces)` in `PiecesRules.js`. Finds the king of the given color, then checks whether any opponent piece could legally move onto the king's square right now via the existing `rules()` function — no duplicated movement logic.
- Turn-independent, as specified — purely a read of a static position.
- Returns `false` if the given color's king isn't present, rather than throwing.
- Not wired into `Board.js` or any UI, per spec — this ticket adds the capability only. T6 (no moving into check) is where it gets consumed.

## How this was verified
- `npm test`: all suites pass — 8 new tests covering rook/knight/pawn/queen attacks on the king, a blocked path correctly not counting as check, no reachable attacker, a same-color piece not counting as a threat, and a missing king returning `false`.
- Reviewed the diff against every AC bullet in #16.

## Test plan
- [x] `npm test` passes
- [x] AC in #16 reviewed against the diff


---
_Generated by [Claude Code](https://claude.ai/code/session_01NULuXwvh8pynRN9gpQqEgu)_