### PR TITLE
T6: no moving into check

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -164,7 +164,7 @@ Determine whether a given king is currently in check, given a board position.
 ### T6 — No moving into check
 A move that would leave the moving player's own king in check must be rejected,
 even if it's otherwise legal for that piece.
-**Status:** Ready
+**Status:** Done
 **Depends on:** T5
 
 **Acceptance criteria:**

--- a/src/components/board/Board.js
+++ b/src/components/board/Board.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useContext } from "react";
 import "./Board.css";
 import Square from "../square/Square";
 import PieceComponent from "../piece/Piece";
-import { rules } from "../piece/PiecesRules";
+import { rules, isKingInCheck } from "../piece/PiecesRules";
 import { ErrorContext } from "../errorBoundary/ErrorBoundary";
 
 const deselectSquareInArray = (squares, selectedSquare) => {
@@ -44,6 +44,16 @@ const applyMoveToPieces = (previousSelectedPiece, clickedSquare, pieces) => {
         return piece;
       }
     });
+};
+
+export const wouldLeaveOwnKingInCheck = (previousSelectedPiece, clickedSquare, pieces) => {
+  const resultingPieces = applyMoveToPieces(
+    previousSelectedPiece,
+    clickedSquare,
+    pieces
+  );
+
+  return isKingInCheck(previousSelectedPiece.isWhite, resultingPieces);
 };
 
 const shouldDeselectPreviousSquare = (selectedSquare, id) =>
@@ -140,7 +150,8 @@ function Board({ pieces, setPieces, isWhiteTurn, setIsWhiteTurn }) {
             currentPosition,
             nextPosition,
             pieces,
-          })
+          }) &&
+          !wouldLeaveOwnKingInCheck(previousSelectedPiece, clickedSquare, copyPieces)
         ) {
           const copyPiecesArrayWithNewPosition = applyMoveToPieces(
             previousSelectedPiece,

--- a/src/components/board/__tests__/Board.test.js
+++ b/src/components/board/__tests__/Board.test.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { render, fireEvent, cleanup } from "@testing-library/react";
-import Board from "../Board";
+import Board, { wouldLeaveOwnKingInCheck } from "../Board";
 import { getStartPosition } from "../../game/GameUtils";
 
 afterEach(cleanup);
@@ -148,5 +148,97 @@ describe("Board capture logic", () => {
     //Assert - both pieces still present, nothing was removed or overlapped
     const pieceEls = container.querySelectorAll('[data-cy="piece"]');
     expect(pieceEls.length).toBe(2);
+  });
+});
+
+describe("wouldLeaveOwnKingInCheck", () => {
+  test("is true when the king moves into a square an opponent piece attacks", () => {
+    //Arrange
+    const king = { id: "kingA", isWhite: true, type: 6, positionY: 1, positionX: 5 };
+    const pieces = [
+      king,
+      { id: "rookB", isWhite: false, type: 2, positionY: 8, positionX: 4 },
+    ];
+    const clickedSquare = { positionY: 1, positionX: 4 };
+
+    //Act
+    const result = wouldLeaveOwnKingInCheck(king, clickedSquare, pieces);
+
+    //Assert
+    expect(result).toBe(true);
+  });
+
+  test("is true when moving a piece exposes the king to an attack it was blocking", () => {
+    //Arrange
+    const blocker = { id: "knightA", isWhite: true, type: 3, positionY: 1, positionX: 3 };
+    const pieces = [
+      { id: "kingA", isWhite: true, type: 6, positionY: 1, positionX: 5 },
+      blocker,
+      { id: "rookB", isWhite: false, type: 2, positionY: 1, positionX: 1 },
+    ];
+    const clickedSquare = { positionY: 3, positionX: 4 };
+
+    //Act
+    const result = wouldLeaveOwnKingInCheck(blocker, clickedSquare, pieces);
+
+    //Assert
+    expect(result).toBe(true);
+  });
+
+  test("is false when the move doesn't expose the king to any attack", () => {
+    //Arrange
+    const king = { id: "kingA", isWhite: true, type: 6, positionY: 1, positionX: 5 };
+    const pieces = [king];
+    const clickedSquare = { positionY: 2, positionX: 5 };
+
+    //Act
+    const result = wouldLeaveOwnKingInCheck(king, clickedSquare, pieces);
+
+    //Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe("Board rejects moves that leave your own king in check", () => {
+  const pinnedRookScenario = [
+    { id: "kingA", isWhite: true, type: 6, positionY: 1, positionX: 5 },
+    { id: "rookA", isWhite: true, type: 2, positionY: 1, positionX: 3 },
+    { id: "rookB", isWhite: false, type: 2, positionY: 1, positionX: 1 },
+  ];
+
+  test("a legal-for-the-piece move is rejected if it leaves the king in check", () => {
+    //Arrange
+    const { container, getByTestId } = render(
+      <TestGame initialPieces={pinnedRookScenario} />
+    );
+
+    //Act - the pinned rook has a clear, otherwise-legal path off the rank
+    clickSquare(container, 1, 3);
+    clickSquare(container, 4, 3);
+
+    //Assert - rejected: rook didn't move, still white's turn
+    const originalSquare = container.querySelectorAll('[data-cy="square"]')[
+      squareIndexFor(1, 3)
+    ];
+    expect(originalSquare.querySelector('[data-cy="piece"]')).not.toBeNull();
+    expect(getByTestId("turn").textContent).toBe("white");
+  });
+
+  test("the same pinned piece can still move along the line it's blocking", () => {
+    //Arrange
+    const { container, getByTestId } = render(
+      <TestGame initialPieces={pinnedRookScenario} />
+    );
+
+    //Act - moving along the rank still blocks the attacking rook, king stays safe
+    clickSquare(container, 1, 3);
+    clickSquare(container, 1, 4);
+
+    //Assert - allowed: rook moved, turn passed to black
+    const destinationSquare = container.querySelectorAll('[data-cy="square"]')[
+      squareIndexFor(1, 4)
+    ];
+    expect(destinationSquare.querySelector('[data-cy="piece"]')).not.toBeNull();
+    expect(getByTestId("turn").textContent).toBe("black");
   });
 });


### PR DESCRIPTION
## Summary
Implements T6 against the acceptance criteria in #18.

- New exported `wouldLeaveOwnKingInCheck(previousSelectedPiece, clickedSquare, pieces)` in `Board.js`: simulates the move via the existing `applyMoveToPieces`, then checks the result with `isKingInCheck` (T5). No duplicated logic.
- `squareClicked`'s move-attempt branch now requires both `shouldMovePiece(...)` (existing piece-legality check) and `!wouldLeaveOwnKingInCheck(...)` before committing a move. A move that fails the check-safety test behaves exactly like any other illegal move — silent no-op, no state change, turn doesn't switch.
- No special-casing needed for: the king moving into an attacked square, a pinned piece exposing the king, or a player already in check making a non-escaping move — all three are just consequences of simulating the resulting position and checking it, per the spec.

## How this was verified
- `npm test`: all suites pass — 52 tests total (5 new): 3 unit tests for `wouldLeaveOwnKingInCheck` directly (king into attack, a pin exposing the king, a safe move) and 2 Board-level integration tests with a pinned-rook scenario — moving the pin off its line is rejected, moving it along the line it's blocking (still safe) is allowed.
- Built a production bundle and re-ran the same standard-opening click-through used to verify T1/T4 — no regression to ordinary play.
- Reviewed the diff against every AC bullet in #18.

## Test plan
- [x] `npm test` passes
- [x] AC in #18 reviewed against the diff
- [x] Manual click-through against a production build shows no regression to ordinary play


---
_Generated by [Claude Code](https://claude.ai/code/session_01NULuXwvh8pynRN9gpQqEgu)_